### PR TITLE
Optimised drawFastHLine

### DIFF
--- a/libraries/Gamebuino-Meta/src/utility/Graphics/Image.cpp
+++ b/libraries/Gamebuino-Meta/src/utility/Graphics/Image.cpp
@@ -292,6 +292,35 @@ Image::~Image() {
 	}
 }
 
+void Image::drawFastHLine(int16_t x, int16_t y, int16_t w) {
+	if (colorMode == ColorMode::rgb565)
+	{
+
+		// Don't draw if we are outside the screen
+		if (x + w <= 0 || x >= _width || y < 0 || y >= _height) return;
+		
+		// Clamp value so we don't go outside the buffer
+		int16_t new_x = max(x,0);
+		int bound = new_x + min(w - (new_x - x),_width-new_x);
+
+		if (new_x%2 == 1)
+		{
+			_buffer[y * _width + new_x] = (uint16_t)color.c;
+			new_x ++;
+		}
+		
+		_buffer[y * _width + bound-1] = (uint16_t)color.c;
+		for (int i = new_x>>1; i < (bound>>1); i++)
+		{
+			((uint32_t*)_buffer)[(y * (_width>>1)) + i] = ((uint16_t)color.c << 16) | (uint16_t)color.c;
+		}
+	}
+	else
+	{
+		drawLine(x, y, x+w-1, y);
+	}
+}
+
 uint16_t Image::getBufferSize() {
 	uint16_t bytes = 0;
 	if (colorMode == ColorMode::index) {

--- a/libraries/Gamebuino-Meta/src/utility/Graphics/Image.h
+++ b/libraries/Gamebuino-Meta/src/utility/Graphics/Image.h
@@ -91,6 +91,8 @@ public:
 	Image(uint16_t w, uint16_t h, char* filename, uint8_t fl = DEFAULT_FRAME_LOOP);
 	void init(uint16_t w, uint16_t h, char* filename, uint8_t fl = DEFAULT_FRAME_LOOP);
 	
+	virtual void drawFastHLine(int16_t x, int16_t y, int16_t w) override __attribute__((optimize("-O3")));
+
 	
 	void nextFrame();
 	void setFrame(uint16_t frame);


### PR DESCRIPTION
Optimised drawFastHLine by overriding it in the Image class.

The optimisation uses 32bit long writes to draw horizontal lines in an efficient manner. Only the rgb565 mode version of the method has been optimised, the other one kept the original behaviour.