### PR TITLE
Fixed noise inducing bug in the Sound library

### DIFF
--- a/libraries/Gamebuino-Meta/src/utility/Sound/Sound.cpp
+++ b/libraries/Gamebuino-Meta/src/utility/Sound/Sound.cpp
@@ -322,6 +322,7 @@ void Audio_Handler (void) {
 					output += (channels[i].buffer[channels[i].index++] - 0x80);
 				} else if (!channels[i].last) {
 					channels[i].index = 0;
+					output += (channels[i].buffer[channels[i].index++] - 0x80);
 				} else if (channels[i].loop) {
 					handlers[i]->rewind();
 				} else {


### PR DESCRIPTION
This bug is caused by the Sound Interrupt not playing a sample whenever the Raw sound buffer loops, resulting in a audible 'pop'.

This fix has been tested using a 44100hz mono 8bit wav music, and noticing that the pops disappears once fix is applied. It also works when using 22050Hz songs.