### PR TITLE
Small fix to the Sound Fx engine

### DIFF
--- a/libraries/Gamebuino-Meta/src/utility/Sound/Sound_FX.cpp
+++ b/libraries/Gamebuino-Meta/src/utility/Sound/Sound_FX.cpp
@@ -39,7 +39,7 @@ void Sound_Handler_FX::init() {
 
 void Sound_Handler_FX::update() {
 	// Check if we should advance in the pattern
-	if (_current_Sound_FX_time >= _current_Sound_FX.length) {
+	if (_current_Sound_FX_time != UINT32_MAX && _current_Sound_FX_time >= _current_Sound_FX.length) {
 		// Check if there is still fx to play
 		if ((_current_pattern_length != 0 && _current_pattern_Sound_FX < _current_pattern_length - 1) || (_current_pattern_length == 0 && ((uint32_t)_current_pattern[_current_pattern_Sound_FX].type & (uint32_t) Sound_FX_Wave::CONTINUE_FLAG))) {
 			_current_pattern_Sound_FX++;


### PR DESCRIPTION
Before, patterns would try each frame to play the next fx even if there was no fx. While not problematic, it can cause a small bug in a very specific edge case that I encountered while making the FX creation tool.

Now pattern will only try once to play the next pattern, and will stop if there is none.