### PR TITLE
Fixed noise on fx when playing after reboot

### DIFF
--- a/libraries/Gamebuino-Meta/src/utility/Sound/Sound.cpp
+++ b/libraries/Gamebuino-Meta/src/utility/Sound/Sound.cpp
@@ -213,10 +213,13 @@ int8_t Sound::play(Sound_Handler* handler, bool loop) {
 #endif // SOUND_CHANNELS
 }
 
+// Get optimized away if fx is not used
+uint32_t fx_sound_buffer[SOUND_BUFFERSIZE/4];
+
 void init_fx_channel() {
 	if (fx_channel.handler == nullptr){
 		fx_channel.size = SOUND_BUFFERSIZE;
-		fx_channel.buffer = (int8_t*) new uint32_t[fx_channel.size / 4]; // Wierd cast so buffer is 32bit aligned
+		fx_channel.buffer = (int8_t*)fx_sound_buffer;
 		memset(fx_channel.buffer, 0, fx_channel.size);
 		fx_channel.index = 0;
 		fx_channel.handler = new Sound_Handler_FX(&fx_channel);

--- a/libraries/Gamebuino-Meta/src/utility/Sound/Sound_FX.cpp
+++ b/libraries/Gamebuino-Meta/src/utility/Sound/Sound_FX.cpp
@@ -21,7 +21,6 @@ Authors:
 */
 
 #include "Sound_FX.h"
-#include <Gamebuino-Meta.h>
 
 namespace Gamebuino_Meta {
 void Sound_Handler_FX::init() {
@@ -66,7 +65,7 @@ void Sound_Handler_FX::update() {
 		}
 	}
 	else if (_current_Sound_FX_time != UINT32_MAX) {
-		memset(parent_channel->buffer, 0x80, parent_channel->size);
+		memset(parent_channel->buffer, 0, parent_channel->size);
 		_current_Sound_FX_time = UINT32_MAX;
 	}
 	else{

--- a/libraries/Gamebuino-Meta/src/utility/Sound/Sound_FX.cpp
+++ b/libraries/Gamebuino-Meta/src/utility/Sound/Sound_FX.cpp
@@ -21,6 +21,7 @@ Authors:
 */
 
 #include "Sound_FX.h"
+#include <Gamebuino-Meta.h>
 
 namespace Gamebuino_Meta {
 void Sound_Handler_FX::init() {
@@ -65,7 +66,7 @@ void Sound_Handler_FX::update() {
 		}
 	}
 	else if (_current_Sound_FX_time != UINT32_MAX) {
-		memset(parent_channel->buffer, 0, parent_channel->size);
+		memset(parent_channel->buffer, 0x80, parent_channel->size);
 		_current_Sound_FX_time = UINT32_MAX;
 	}
 	else{


### PR DESCRIPTION
Replaced dynamic memory allocation with a static array. The array won't be created if the fx library is not used.