### PR TITLE
Let sound play at normal speed, also for non-default frequencies

### DIFF
--- a/src/utility/Sound/Sound_FX.h
+++ b/src/utility/Sound/Sound_FX.h
@@ -67,7 +67,7 @@ private:
 	static const uint8_t VOLUME_SWEEP_SCALE = 8;
 	static const uint8_t PERIOD_START_SCALE = FPP;
 	static const uint8_t PERIOD_SWEEP_SCALE = 7;
-	static const int32_t LENGTH_SCALE = 441 * 2 / SR_DIVIDER;
+	static const int32_t LENGTH_SCALE = 441 * 2;
 public:
 
 


### PR DESCRIPTION
Minor fix which ensures that after changing the SOUND_FREQ define, sound effects still play at the same speed.

To reproduce the problem, create a sound effect and play it. Next change SOUND_FREQ to 22050, rebuild with the new setting. The sound effect now plays twice as fast. This change fixes that. 