### PR TITLE
Sound fx fixes

### DIFF
--- a/src/config/config-default.h
+++ b/src/config/config-default.h
@@ -108,6 +108,16 @@
 #define SOUND_BUFFERSIZE (2048 * SOUND_FREQ / 44100)
 #endif
 
+// Even though it default to same value as SOUND_BUFFER size, give the FX its own size so the
+// buffer sizes can be optimized independently. For sound effects there should never be a need to
+// have a buffer much larger than required to contain the samples played in a single update cycle.
+// This will only introduce an unnecessary delay before a sound effect is played. However, for
+// music streamed from a WAV file, a bigger buffer might help mitigate occassional delays when
+// reading from SD.
+#ifndef SOUND_FX_BUFFERSIZE
+#define SOUND_FX_BUFFERSIZE (2048 * SOUND_FREQ / 44100)
+#endif
+
 #ifndef SOUND_ENABLE_FX
 #define SOUND_ENABLE_FX 1
 #endif

--- a/src/utility/Sound/Sound.cpp
+++ b/src/utility/Sound/Sound.cpp
@@ -220,12 +220,12 @@ int8_t Sound::play(Sound_Handler* handler, bool loop) {
 }
 
 // Get optimized away if fx is not used
-uint32_t fx_sound_buffer[SOUND_BUFFERSIZE/4];
+uint32_t fx_sound_buffer[SOUND_FX_BUFFERSIZE/4];
 
 void init_fx_channel() {
 #if SOUND_CHANNELS > 0
 	if (fx_channel.handler == nullptr){
-		fx_channel.size = SOUND_BUFFERSIZE;
+		fx_channel.size = SOUND_FX_BUFFERSIZE;
 		fx_channel.buffer = (int8_t*)fx_sound_buffer;
 		memset(fx_channel.buffer, 0, fx_channel.size);
 		fx_channel.index = 0;

--- a/src/utility/Sound/Sound_FX.cpp
+++ b/src/utility/Sound/Sound_FX.cpp
@@ -108,7 +108,7 @@ void Sound_Handler_FX::update() {
 				return;
 			} else if (_firstZeroP > _headP) {
 				// Stop once buffer contains only zeroes
-				maxSamples= min(maxSamples, _firstZeroP - _headP);
+				maxSamples = min(maxSamples, _firstZeroP - _headP);
 			}
 
 			generateSilence(_headP + maxSamples);

--- a/src/utility/Sound/Sound_FX.cpp
+++ b/src/utility/Sound/Sound_FX.cpp
@@ -34,41 +34,78 @@ void Sound_Handler_FX::init() {
 
 	_pitch_scale = 1 << FPP;
 
+	_headP = (uint32_t *)parent_channel->buffer;
+
 	resetGenerators();
 }
 
 void Sound_Handler_FX::update() {
-	// Check if we should advance in the pattern
-	if (_current_Sound_FX_time != UINT32_MAX && _current_Sound_FX_time >= _current_Sound_FX_length) {
-		// Check if there is still fx to play
-		if ((_current_pattern_length != 0 && _current_pattern_Sound_FX < _current_pattern_length - 1) 
-			|| (_current_pattern_length == 0 && (_current_pattern[_current_pattern_Sound_FX].continue_flag))) {
-			_current_pattern_Sound_FX++;
-			play(_current_pattern[_current_pattern_Sound_FX]);
-		}
-	}
+	// Set target to completely fill buffer (given current index, which is continuously changing)
+	// Note: Casting before adding offset to ensure index is properly rounded down.
+	uint32_t* targetHeadP = ((uint32_t *)parent_channel->buffer) + (parent_channel->index >> 2);
 
+	uint32_t* maxHeadP = ((uint32_t *)parent_channel->buffer) + (parent_channel->size >> 2);
 
-	// Generate sound
-	if (_current_Sound_FX_time < _current_Sound_FX_length) {
-		switch (_current_Sound_FX.type) {
-		case Sound_FX_Wave::NOISE:
-			generateNoise();
-			break;
-		case Sound_FX_Wave::SQUARE:
-			generateSquare();
-			break;
-		default:
-			// WTF man
-			break;
+	// Fill buffer in one or more iterations. Multiple iterations are needed when the end of the
+	// cyclic buffer is reached, or the active sound pattern is finished
+	while (_headP != targetHeadP) {
+		// Check if we should advance in the pattern
+		if (_current_Sound_FX_time != UINT32_MAX && _current_Sound_FX_time >= _current_Sound_FX_length) {
+			// Check if there is still fx to play
+			if ((
+				_current_pattern_length != 0 &&
+				_current_pattern_Sound_FX < _current_pattern_length - 1
+			) || (
+				_current_pattern_length == 0 &&
+				_current_pattern != nullptr &&
+				_current_pattern[_current_pattern_Sound_FX].continue_flag
+			)) {
+				_current_pattern_Sound_FX++;
+				play(_current_pattern[_current_pattern_Sound_FX]);
+			} else {
+				_current_Sound_FX_time = UINT32_MAX;
+			}
 		}
-	}
-	else if (_current_Sound_FX_time != UINT32_MAX) {
-		memset(parent_channel->buffer, 0, parent_channel->size);
-		_current_Sound_FX_time = UINT32_MAX;
-	}
-	else{
-		//do nothing
+
+		// Generate sound
+
+		// The maximum number of samples that can be filled without passing the target mark or the
+		// end of the buffer cyclic buffer. Checking this here is more efficient than doing so in
+		// inner loops that generate the actually sound samples.
+		uint16_t maxSamples;
+		if (_headP < targetHeadP) {
+			maxSamples = targetHeadP - _headP;
+		} else {
+			maxSamples = maxHeadP - _headP;
+		}
+
+		if (_current_Sound_FX_time < _current_Sound_FX_length) {
+			// Ensure at least one sample is added, to ensure termination
+			maxSamples = max(1, min(
+				maxSamples,
+				((_current_Sound_FX_length - _current_Sound_FX_time) >> 2) / SR_DIVIDER
+			));
+			_current_Sound_FX_time += 4 * SR_DIVIDER * maxSamples;
+
+			switch (_current_Sound_FX.type) {
+				case Sound_FX_Wave::NOISE:
+					generateNoise(_headP + maxSamples);
+					break;
+				case Sound_FX_Wave::SQUARE:
+					generateSquare(_headP + maxSamples);
+					break;
+				default:
+					// WTF man
+					break;
+			}
+		} else {
+			generateSilence(_headP + maxSamples);
+		}
+
+		if (_headP == maxHeadP) {
+			// Reached end of cyclic buffer. Continue at the beginning.
+			_headP = (uint32_t *)parent_channel->buffer;
+		}
 	}
 }
 
@@ -104,10 +141,9 @@ void Sound_Handler_FX::resetGenerators() {
 	_square_polarity = 1;
 }
 
-void Sound_Handler_FX::generateNoise() {
-	uint32_t target = parent_channel->index;
+void Sound_Handler_FX::generateNoise(uint32_t* endP) {
 	static uint16_t lfsr = 1;
-	do{
+	do {
 		int8_t volume = getVolume();
 
 		if (--_noise_period <= 0) {
@@ -119,23 +155,16 @@ void Sound_Handler_FX::generateNoise() {
 		uint8_t v = (uint8_t)volume;
 		uint32_t sample = (v << 24) | (v << 16) | (v << 8) | v;
 
-		_head_index = (_head_index + 1) % (parent_channel->size >> 2);
-		_current_Sound_FX_time += 4 * SR_DIVIDER;
-		((uint32_t*)(&parent_channel->buffer[0]))[_head_index] = sample;
-	} while (_head_index != target >> 2);
+		*_headP++ = sample;
+	} while (_headP != endP);
 }
 
-void Sound_Handler_FX::generateSquare() {
-	uint32_t target = parent_channel->index;
-	uint32_t * buffer_ptr = ((uint32_t*)(&parent_channel->buffer[0]));
-
+void Sound_Handler_FX::generateSquare(uint32_t* endP) {
 	do {
 		uint32_t sample = 0;
 		int8_t volume = getVolume();
-		if (_square_period <= (4 << FPP))
-		{
-			for (int i = 0; i < 4; i++)
-			{
+		if (_square_period <= (4 << FPP)) {
+			for (int i = 0; i < 4; i++) {
 				_square_period -= (1 << FPP);
 				if (_square_period <= 0) {
 					_square_period += max(getFrequency() / SR_DIVIDER, 0);
@@ -145,22 +174,21 @@ void Sound_Handler_FX::generateSquare() {
 				uint8_t v = (uint8_t)vol;
 				sample |= (v << (8 * i));
 			}
-		}
-		else
-		{
+		} else {
 			_square_period -= (4 << FPP);
 			volume = _square_polarity ? volume : -volume;
 			uint8_t v = (uint8_t)volume;
 			sample = (v << 24) | (v << 16) | (v << 8) | v;
 		}
 
-		_head_index = (_head_index + 1) % (parent_channel->size >> 2);
-		_current_Sound_FX_time += 4 * SR_DIVIDER;
-		buffer_ptr[_head_index] = sample;
-	} while (_head_index != target >> 2);
-
+		*_headP++ = sample;
+	} while (_headP != endP);
 }
 
-
+void Sound_Handler_FX::generateSilence(uint32_t* endP) {
+	do {
+		*_headP++ = 0;
+	} while (_headP != endP);
+}
 
 } // Namespace Gamebuino_META

--- a/src/utility/Sound/Sound_FX.h
+++ b/src/utility/Sound/Sound_FX.h
@@ -79,8 +79,9 @@ public:
 
 	void init();
 	void update();
-	void generateNoise() __attribute__((optimize("-O3"))); // Handle noise instrument
-	void generateSquare() __attribute__((optimize("-O3")));
+	void generateNoise(uint32_t* endP) __attribute__((optimize("-O3"))); // Handle noise instrument
+	void generateSquare(uint32_t* endP) __attribute__((optimize("-O3")));
+	void generateSilence(uint32_t* endP) __attribute__((optimize("-O3")));
 
 	void play(const Gamebuino_Meta::Sound_FX & Sound_FX);
 	void play(const Gamebuino_Meta::Sound_FX * const pattern, uint8_t length);
@@ -98,8 +99,7 @@ public:
 	int32_t _current_Sound_FX_period_sweep;
 	uint32_t _current_Sound_FX_length;
 
-
-	uint16_t _head_index;
+	uint32_t* _headP;
 	int16_t _pitch_scale;
 
 	int32_t _noise_period;

--- a/src/utility/Sound/Sound_FX.h
+++ b/src/utility/Sound/Sound_FX.h
@@ -100,6 +100,7 @@ public:
 	uint32_t _current_Sound_FX_length;
 
 	uint32_t* _headP;
+	uint32_t* _firstZeroP;
 	int16_t _pitch_scale;
 
 	int32_t _noise_period;


### PR DESCRIPTION
This fixes several problems in the Sound FX implementation.

Firstly, irrespective how much time was still remaining for a pattern, it always filled the complete buffer. This typically meant that sounds lasted a bit longer than specified, which was especially noticeable for short patterns.

Secondly, when no more patterns remained, the entire buffer would be cleared via a memset.
This would typically wipe samples from the last pattern which still had to be played.
This was especially noticeable after increasing the buffer size and/or decreasing the sample rate. For the default buffer size and sample rate this effect was minimal, as during a single update period most of the buffer would be emptied (as 44100 / 25 ~= 2048).

Thirdly, the implementation could be made more efficient, in particular the inner loops that generate the samples.

One possible drawback of the revised code is that the original code did not use CPU when no sound effect was active (by relying on the full clear by the memset). That's not the case with the current implementation. It continuously writes zeros to the buffer, albeit quite efficiently.

Such an optimization can still be added, but requires a bit more book-keeping. In particular, when the sound effect is completely writter to the buffer, zeros need to be written to the buffer for several update cycles until the entire buffer is zeroed. It's however arguable if such an optimization is worth the effort. If a game uses sound effects, it should budget enough CPU cycles so that utilisation does not exceed 100% when sounds are playing. Therefore I did not (yet?) add it.