### PR TITLE
Preserve original image palette when storing images

### DIFF
--- a/src/utility/Display-ST7735/Display-ST7735.cpp
+++ b/src/utility/Display-ST7735/Display-ST7735.cpp
@@ -537,24 +537,22 @@ void Display_ST7735::drawImage(int16_t x, int16_t y, Image& img){
 #endif
 		dataMode();
 
-		//start sending lines and processing them in parallel using DMA
-		for (uint16_t j = 0; j < h; j++) { //vertical coordinate in source image, start from the second line
+		Color *index = Graphics::colorIndex;
+		uint16_t *src = img._buffer;
+		uint16_t *srcEnd = src + w * h / 4; // Four pixels per value
 
-			//length is the number of destination pixels
+		//start sending lines and processing them in parallel using DMA
+		while (src < srcEnd) {
 			uint16_t *dest = preBufferLine;
-			uint16_t *src = img._buffer + ((j * w) / 4);
-			Color *index = Graphics::colorIndex;
-			uint16_t length = w;
-			for (uint16_t i = 0; i < length / 4; i++) {
-				uint16_t index1 = (src[i] >> 4) & 0x000F;
-				uint16_t index2 = (src[i] >> 0) & 0x000F;
-				uint16_t index3 = (src[i] >> 12) & 0x000F;
-				uint16_t index4 = (src[i] >> 8) & 0x000F;
+			uint16_t *destEnd = preBufferLine + w;
+			while (dest < destEnd) {
+				uint16_t val = *src;
 				//change pixel order (because of words endianness) at the same time
-				dest[i * 4] = swap_endians_16((uint16_t)index[index1]);
-				dest[(i * 4) + 1] = swap_endians_16((uint16_t)index[index2]);
-				dest[(i * 4) + 2] = swap_endians_16((uint16_t)index[index3]);
-				dest[(i * 4) + 3] = swap_endians_16((uint16_t)index[index4]);
+				*dest++ = swap_endians_16((uint16_t)index[(val >>  4) & 0x000F]);
+				*dest++ = swap_endians_16((uint16_t)index[(val >>  0) & 0x000F]);
+				*dest++ = swap_endians_16((uint16_t)index[(val >> 12) & 0x000F]);
+				*dest++ = swap_endians_16((uint16_t)index[(val >>  8) & 0x000F]);
+				++src;
 			}
 
 			//swap buffers pointers

--- a/src/utility/Display-ST7735/Display-ST7735.cpp
+++ b/src/utility/Display-ST7735/Display-ST7735.cpp
@@ -127,7 +127,7 @@ void dma_tft_error_callback(Adafruit_ZeroDMA *dma) {
 
 #endif // CUSTOM_TFT_FUNCTIONS
 
-inline uint16_t swapcolor(uint16_t x) { 
+inline uint16_t swapcolor(uint16_t x) {
 	return (x << 11) | (x & 0x07E0) | (x >> 11);
 }
 
@@ -183,7 +183,7 @@ void Display_ST7735::writedata(uint8_t c) {
 	SPI.beginTransaction(tftSPISettings);
 #endif
 	dataMode();
-		
+
 	//Serial.print("D ");
 	spiwrite(c);
 
@@ -312,12 +312,12 @@ void Display_ST7735::commandList(const uint8_t *addr) {
 void Display_ST7735::commonInit() {
 	csport = &(PORT->Group[1].OUT.reg);
 	rsport = &(PORT->Group[1].OUT.reg);
-	
+
 	cspinmask = (1 << 22);
 	rspinmask = (1 << 23);
 	PORT->Group[1].DIR.reg |= cspinmask;
 	PORT->Group[1].DIR.reg |= rspinmask;
-	
+
 
 #ifdef ENABLE_IDLE_TOGGLE_PIN
 	PORT->Group[0].DIR.reg |= (1 << ENABLE_IDLE_TOGGLE_PIN);
@@ -353,7 +353,7 @@ void Display_ST7735::init() {
 
 	writecommand(ST7735_MADCTL);
 	writedata(0xC0);
-	
+
 	// initialize DMA
 #if !CUSTOM_TFT_FUNCTIONS
 	tftDMA.setTrigger(SERCOM4_DMAC_ID_TX);
@@ -392,7 +392,7 @@ void Display_ST7735::setAddrWindow(uint8_t x0, uint8_t y0, uint8_t x1, uint8_t y
 
 	writecommand(ST7735_CASET); // Column addr set
 	writedata(0x00);
-	writedata(x0);		 // XSTART 
+	writedata(x0);		 // XSTART
 	writedata(0x00);
 	writedata(x1);		 // XEND
 
@@ -537,7 +537,7 @@ void Display_ST7735::drawImage(int16_t x, int16_t y, Image& img){
 #endif
 		dataMode();
 
-		Color *index = Graphics::colorIndex;
+		Color *index = img.colorIndex;
 		uint16_t *src = img._buffer;
 		uint16_t *srcEnd = src + w * h / 4; // Four pixels per value
 
@@ -584,14 +584,13 @@ void Display_ST7735::drawImage(int16_t x, int16_t y, Image& img){
 
 		return;
 	}
-	
+
 	Graphics::drawImage(x, y, img); //fallback to the usual
 }
 
-void bufferIndexLine(uint16_t* preBufferLine, uint16_t* img_buffer, int16_t w, uint16_t j) {
+void bufferIndexLine(uint16_t* preBufferLine, uint16_t* img_buffer, int16_t w, uint16_t j, Color *index) {
 	uint16_t *dest = preBufferLine;
 	uint16_t *src = img_buffer + ((j * w) / 4);
-	Color *index = Graphics::colorIndex;
 	uint16_t length = w;
 	for (uint16_t i = 0; i < length / 4; i++) {
 		uint16_t index1 = (src[i] >> 4) & 0x000F;
@@ -623,7 +622,7 @@ void Display_ST7735::drawImage(int16_t x, int16_t y, Image& img, int16_t w2, int
 	}
 
 	//no scaling
-	if ((w == w2) && (h == h2)) { 
+	if ((w == w2) && (h == h2)) {
 		drawImage(x, y, img);
 		return;
 	}
@@ -639,10 +638,10 @@ void Display_ST7735::drawImage(int16_t x, int16_t y, Image& img, int16_t w2, int
 #endif // USE_TFT_DESCRIPTORS
 		uint16_t *preBufferLine = preBufferLineArray;
 		uint16_t *sendBufferLine = sendBufferLineArray;
-		
+
 		//set the window to the whole screen
 		setAddrWindow(0, 0, _width - 1, _height - 1);
-		
+
 		//initiate SPI
 #if CUSTOM_TFT_SPI_FUNCTIONS
 		gamebuino_meta_tft_spi_begin_transaction();
@@ -700,7 +699,7 @@ void Display_ST7735::drawImage(int16_t x, int16_t y, Image& img, int16_t w2, int
 			for (uint16_t j = 0; j < h; j++) { //vertical coordinate in source image, start from the second line
 
 				// prepare the next line while we'r at it
-				bufferIndexLine(preBufferLine, img._buffer, w, j);
+				bufferIndexLine(preBufferLine, img._buffer, w, j, img.colorIndex);
 #if !USE_TFT_DESCRIPTORS
 				memcpy(&preBufferLine[w2], preBufferLine, w2 * 2);
 				if (j > 0) {
@@ -751,7 +750,7 @@ void Display_ST7735::pushColor(uint16_t c) {
 	SPI.beginTransaction(tftSPISettings);
 #endif
 	dataMode();
-	
+
 	spiwrite(c >> 8);
 	spiwrite(c);
 
@@ -775,7 +774,7 @@ void Display_ST7735::_drawPixel(int16_t x, int16_t y) {
 	SPI.beginTransaction(tftSPISettings);
 #endif
 	dataMode();
-	
+
 	spiwrite((uint16_t)color.c >> 8);
 	spiwrite((uint16_t)color.c);
 
@@ -795,7 +794,7 @@ void Display_ST7735::drawFastVLine(int16_t x, int16_t y, int16_t h) {
 	setAddrWindow(x, y, x, y+h-1);
 
 	uint8_t hi = (uint16_t)Graphics::color.c >> 8, lo = (uint16_t)Graphics::color.c;
-	
+
 #if CUSTOM_TFT_SPI_FUNCTIONS
 	gamebuino_meta_tft_spi_begin_transaction();
 #else
@@ -851,7 +850,7 @@ void Display_ST7735::fillRect(int16_t x, int16_t y, int16_t w, int16_t h) {
 	setAddrWindow(x, y, x+w-1, y+h-1);
 
 	uint8_t hi = (uint16_t)Graphics::color.c >> 8, lo = (uint16_t)Graphics::color.c;
-	
+
 #if CUSTOM_TFT_SPI_FUNCTIONS
 	gamebuino_meta_tft_spi_begin_transaction();
 #else

--- a/src/utility/Graphics-SD/BMP.h
+++ b/src/utility/Graphics-SD/BMP.h
@@ -48,7 +48,7 @@ public:
 	uint16_t readFrame(uint16_t frame, uint16_t* buf, uint16_t transparentColor, File* file);
 #endif
 	uint32_t getRowSize();
-	
+
 #if USE_SDFAT
 	uint32_t writeHeader(File* file);
 	void writeBuffer(uint16_t* buffer, uint16_t transparentColor, File* file);

--- a/src/utility/Graphics-SD/GMV.h
+++ b/src/utility/Graphics-SD/GMV.h
@@ -55,6 +55,8 @@ private:
 #endif
 	Image* img;
 	void convertFromBMP(BMP& bmp, char* newname);
+	uint8_t convertIndexToDefaultPalette(uint8_t index);
+	uint8_t convertIndexPairToDefaultPalette(uint8_t index);
 #if USE_SDFAT
 	void writeColor(File* f, uint16_t color, uint8_t count);
 	void writeHeader(File* f);

--- a/src/utility/Graphics/Graphics.h
+++ b/src/utility/Graphics/Graphics.h
@@ -134,7 +134,7 @@ public:
 	void clear();
 	void clear(Color bgcolor);
 	void clear(ColorIndex bgcolor);
-	
+
 	void drawCircle(int16_t x0, int16_t y0, int16_t r);
 	void drawCircleHelper(int16_t x0, int16_t y0, int16_t r, uint8_t cornername);
 	void fillCircle(int16_t x0, int16_t y0, int16_t r);
@@ -144,7 +144,7 @@ public:
 	void drawRoundRect(int16_t x0, int16_t y0, int16_t w, int16_t h, int16_t radius);
 	void fillRoundRect(int16_t x0, int16_t y0, int16_t w, int16_t h, int16_t radius);
 
-	
+
 	virtual void drawChar(int16_t x, int16_t y, unsigned char c, uint8_t size);
 	Color setTmpColor(Color c);
 	Color setTmpColor(ColorIndex c);
@@ -175,10 +175,11 @@ public:
 
 
 	static void indexTo565(uint16_t *dest, uint8_t *src, Color *index, uint16_t length, bool skipFirst);
-	static ColorIndex rgb565ToIndex(Color rgb);
-	
+	static ColorIndex rgb565ToIndex(Color rgb, Color *index);
+	ColorIndex rgb565ToIndex(Color rgb) { return rgb565ToIndex(rgb, colorIndex); }
+
 	// additional coordinate prints
-	
+
 	template <uint8_t N>
 	void print(int16_t x, int16_t y, const MultiLang (&l) [N]) {
 		setCursor(x, y);
@@ -189,7 +190,7 @@ public:
 		setCursor(x, y);
 		print(s);
 	};
-	
+
 	template <uint8_t N>
 	void println(int16_t x, int16_t y, const MultiLang (&l) [N]) {
 		setCursor(x, y);
@@ -200,7 +201,7 @@ public:
 		setCursor(x, y);
 		print(s);
 	};
-	
+
 #if USE_PRINTF
 	template <uint8_t N>
 	void printf(int16_t x, int16_t y, const MultiLang (&l) [N], ...) {
@@ -234,7 +235,7 @@ public:
 	static uint8_t alpha;
 	static uint16_t tint;
 	static BlendMode blendMode;
-	static Color *colorIndex;
+	Color *colorIndex;
 	ColorMode colorMode;
 
 #if ARDUINO >= 100
@@ -251,7 +252,7 @@ public:
 	int16_t getCursorY(void) const;
 	uint8_t getFontWidth(void) const;
 	uint8_t getFontHeight(void) const;
-	
+
 	void setPalette(Color* p);
 	void setPalette(const Color* p);
 	Color* getPalette();


### PR DESCRIPTION
When an indexed image was using a non-default palette, its GMV and BMP file would not be correct, as a default palette was assumed.
    
This is fixed here.
    
For this to work, the color index is also made non-static. This was needed because the home menu resets the TFT palette to the default at the start of its update loop. The original palette is stored in a local variable (and restored) but not available elsewhere.

Also included is a minor code simplification/optimization of Display_ST7735::drawImage as well as some trailing white space clean-up.